### PR TITLE
simplify by naming container. chmod 777 wasn't required for me.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,18 +7,13 @@ Also, this Jenkins container allow you to run Docker in a Pipleline stage of a s
 
 Run the container making the host's version of docker available to the Jenkins container
 
-`docker run -d -p 8080:8080 -p 50000:50000 -v /var/run/docker.sock:/var/run/docker.sock -v /usr/bin/docker:/usr/bin/docker fatjenkins:v1`
-
-Get the container id
-
-`docker ps -a`
+`docker run --name jenkins -d -p 8080:8080 -p 50000:50000 -v /var/run/docker.sock:/var/run/docker.sock -v /usr/bin/docker:/usr/bin/docker fatjenkins:v1`
 
 Get the initial login ID that you'll need to access Jenkins
 
-`docker exec -it <CONTAINER_ID> cat /var/jenkins_home/secrets/initialAdminPassword`
+`docker exec -it jenkins cat /var/jenkins_home/secrets/initialAdminPassword`
 
-Changes the rights on the `docker.sock` so that the Jenkins container can run `docker`.
-
-`sudo chmod 777 /var/run/docker.sock`
+Confirm `docker` command works from inside the jenkins container
+`docker exec -it jenkins docker ps`
 
 Go to your browser and spin the Jenkins site up at `localhost:8080`.


### PR DESCRIPTION
I updated the README to make things a little simpler. I added `--name jenkins` to docker run command so that in the next step you can run `docker exec -it jenkins` instead of having them get docker ID. 

I also was able to run `docker exec -it jenkins docker ps` without needing to run `chmod 777` command. I did not do a ton of testing so I'm not sure if the `chmod` is required for building docker images from jenkins container. 